### PR TITLE
Fix thing-at-point-looking-at error

### DIFF
--- a/ivy-erlang-complete.el
+++ b/ivy-erlang-complete.el
@@ -33,6 +33,7 @@
 (require 'counsel)
 (require 'simple)
 (require 'async)
+(require 'thingatpt)
 (if (> emacs-major-version 24) (require 'xref))
 
 (defconst ivy-erlang-complete--base (file-name-directory load-file-name))


### PR DESCRIPTION
When I update all my packages, the `thing-at-point-looking-at` error always occurred. It seems that the package `thingatpt` has been removed from some dependency packages. Here is my solution to fix this error. 